### PR TITLE
Fix password files warning typo

### DIFF
--- a/BlueWindowsTriage2.ps1
+++ b/BlueWindowsTriage2.ps1
@@ -438,7 +438,7 @@ $artifactJobs = @(
             if ($passwordFiles -and $passwordFiles.Count -gt 0) {
                 $passwordFiles | Export-Clixml -Path (Join-Path $outputDir "${logName}_$(Get-Date -Format 'yyyyMMdd_HHmmss').xml")
             } else {
-                Write-Output-Error "No Passsword Files found in $logName log"
+                Write-Output-Error "No Password Files found in $logName log"
             }
             $passwordFiles | ForEach-Object {
                 Copy-Item -Path $_.FullName -Destination (Join-Path $outputDir "PasswordFiles") -Force


### PR DESCRIPTION
## Summary
- fix a typo in the password files warning message in `BlueWindowsTriage2.ps1`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688750baadb8832ca5a38268ccc8661f