### PR TITLE
Add Pester test scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,13 @@ Contributions to improve the script are welcome. Please adhere to the standard G
 ## Contact
 
 For any questions or feedback, please contact the script maintainer at [security@fulco.net](mailto:security@fulco.net).
+
+## Testing
+
+Unit tests are written with [Pester](https://github.com/pester/Pester). To run all tests, execute the following in PowerShell from the repository root:
+
+```powershell
+Invoke-Pester
+```
+
+The tests mock file system operations, so running them will not modify your system.

--- a/tests/BlueWindowsTriage.tests.ps1
+++ b/tests/BlueWindowsTriage.tests.ps1
@@ -1,0 +1,22 @@
+Describe 'BlueWindowsTriage.ps1' {
+    It 'creates output directory and script_log.txt' {
+        $tempDir = Join-Path $env:TEMP "BWTTest_$([guid]::NewGuid())"
+
+        $scriptPath = Join-Path $PSScriptRoot '..' 'BlueWindowsTriage.ps1'
+        $sanitized = Get-Content $scriptPath | Where-Object { $_ -notmatch '^\s*exit\s*$' }
+        $tempScript = Join-Path $env:TEMP 'BWT_Temp.ps1'
+        Set-Content -Path $tempScript -Value $sanitized -Force
+
+        Mock -CommandName New-Item -MockWith { @{'FullName'=$Path} } -Verifiable
+        Mock -CommandName Start-Transcript -MockWith { } -Verifiable
+        Mock -CommandName Stop-Transcript { }
+        Mock -CommandName Start-Job { }
+        Mock -CommandName Wait-Job { }
+        Mock -CommandName Remove-Job { }
+
+        . $tempScript -outputDir $tempDir
+
+        Assert-MockCalled New-Item -ParameterFilter { $ItemType -eq 'Directory' -and $Path -eq $tempDir } -Times 1
+        Assert-MockCalled Start-Transcript -ParameterFilter { $Path -eq "$tempDir\script_log.txt" } -Times 1
+    }
+}


### PR DESCRIPTION
## Summary
- add initial Pester test verifying directory and log file creation
- document how to run tests with Pester

## Testing
- `git status --short`
- *Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.*

------
https://chatgpt.com/codex/tasks/task_e_688750f575a4832c97b0e1bbdc18a39e